### PR TITLE
Fix typo in container registry domain

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            ghrc.io/${{ github.repository_owner }}/ms-qloud:${{ steps.tag-prep.outputs.BUILD_ID }}
+            ghcr.io/${{ github.repository_owner }}/ms-qloud:${{ steps.tag-prep.outputs.BUILD_ID }}
 
       - name: Build image and push to GitHub Container Registry
         uses: docker/build-push-action@v2


### PR DESCRIPTION
Hi `Pouria-yvr/test-action`!

This is not an automatic, 🤖-generated PR, as you can check in my [GitHub profile](https://github.com/p-), I work for GitHub and I am part of the [GitHub Security Lab](https://securitylab.github.com/).

While performing a code search for container registry domains we noticed that this repo contains a misspelled domain name.

If a malicious actor were in control of that misspelled domain, they could potentially perform an attack on the software supply chain of this project and/or steal the credentials used to connect to the container registry (depending on how the misspelled domain name of the container registry is used).
Please fix this typo and check your documentation for similar typos.